### PR TITLE
Improve templates, caching, tests, CI, and linting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,10 @@ updates:
     interval: daily
     time: "11:00"
   open-pull-requests-limit: 10
+- package-ecosystem: github-actions
+  directory: "/"
+  target-branch: v3
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - v3
   pull_request:
-env:
-  GO_VERSION: '1.26'
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -13,8 +11,22 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
-          go-version: ${{ env.GO_VERSION }}
-      - run: go test -v -count=1 ./...
+          go-version-file: go.mod
+      - run: go test -v -count=1 -race -coverprofile=coverage.out ./...
+      - run: go tool cover -func=coverage.out
+
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version-file: go.mod
+      - run: go test -bench=. -benchmem -count=3 -run=^$ ./... | tee benchmark.txt
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: benchmark-results
+          path: benchmark.txt
 
   example:
     runs-on: ubuntu-latest
@@ -22,7 +34,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - run: |
           go run example/main.go
           go run example/main.go -h
@@ -33,5 +45,5 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - run: make lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,7 @@ linters:
     - bidichk
     - bodyclose
     - canonicalheader
+    - clickhouselint
     - containedctx
     - contextcheck
     - copyloopvar
@@ -28,7 +29,7 @@ linters:
     - errname
     - errorlint
     - exhaustive
-    - exhaustruct
+    - exhaustruct_v5
     - exptostd
     - fatcontext
     - forbidigo
@@ -49,7 +50,7 @@ linters:
     - godox
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
     - gosmopolitan
@@ -116,7 +117,6 @@ linters:
     - wrapcheck
     - wsl_v5
     - zerologlint
-    # - wsl
   settings:
     depguard:
       rules:
@@ -129,9 +129,6 @@ linters:
     errcheck:
       check-type-assertions: true
       check-blank: true
-    exhaustruct:
-      exclude:
-        - github.com/urfave/cli/v3\..*
     gocritic:
       enable-all: true
   exclusions:
@@ -143,9 +140,13 @@ linters:
       - std-error-handling
     rules:
       - linters:
+          - exhaustruct_v5
+        text: '^cli\.\w+ is missing fields'
+      - linters:
           - forbidigo
         path: example/
       - linters:
+          - forbidigo
           - testableexamples
           - gocritic
         path: example_test\.go
@@ -159,6 +160,8 @@ formatters:
     - gofmt
     - gofumpt
     - goimports
+    - golines
+    - swaggo
   exclusions:
     generated: lax
     paths:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GO ?= go
 
-GOLANGCI_LINT_VERSION = v2.11.3
+GOLANGCI_LINT_VERSION = v2.13.1
 
 .PHONY: lint
 lint:

--- a/ccli.go
+++ b/ccli.go
@@ -2,7 +2,9 @@ package ccli
 
 import (
 	"fmt"
+	"io"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/fatih/color"
@@ -74,11 +76,31 @@ type Options struct {
 	Disable bool
 }
 
-//nolint:gochecknoglobals // cached defaults to avoid redundant allocations
+//nolint:gochecknoglobals // cached to avoid redundant allocations; color state is fixed after init
 var (
 	cachedDefaults     Options
 	cachedDefaultsOnce sync.Once
+	cachedRootTpl      string
+	cachedCmdTpl       string
+	cachedTplOnce      sync.Once
 )
+
+func buildOptions(opts []Option) Options {
+	options := Options{
+		Blue:    nil,
+		Cyan:    nil,
+		Green:   nil,
+		Red:     nil,
+		Yellow:  nil,
+		Disable: false,
+	}
+
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	return options
+}
 
 func resolveOptions(opts Options) Options {
 	if opts.Disable {
@@ -130,32 +152,37 @@ func defaultOptions() Options {
 	return cachedDefaults
 }
 
+//nolint:gocritic // named returns would conflict with nonamedreturns linter
+func defaultTemplates() (string, string) {
+	cachedTplOnce.Do(func() {
+		opts := defaultOptions()
+		cachedRootTpl = rootCommandHelpTemplate(opts)
+		cachedCmdTpl = commandHelpTemplate(opts)
+	})
+
+	return cachedRootTpl, cachedCmdTpl
+}
+
 // NewCommand creates a new root command with colored help output using
 // default colors. All help templates are set per-command via
 // CustomRootCommandHelpTemplate and CustomHelpTemplate, avoiding
 // global side effects.
 func NewCommand() *cli.Command {
-	return NewCommandWithOptions(defaultOptions())
+	rootTpl, cmdTpl := defaultTemplates()
+
+	return &cli.Command{
+		Writer:                        color.Output,
+		ErrWriter:                     color.Error,
+		CustomRootCommandHelpTemplate: rootTpl,
+		CustomHelpTemplate:            cmdTpl,
+	}
 }
 
 // NewCommandWith creates a new root command with colored help output,
 // configured by functional options. Unset colors fall back to defaults.
 // All help templates are set per-command, avoiding global side effects.
 func NewCommandWith(opts ...Option) *cli.Command {
-	options := Options{
-		Blue:    nil,
-		Cyan:    nil,
-		Green:   nil,
-		Red:     nil,
-		Yellow:  nil,
-		Disable: false,
-	}
-
-	for _, opt := range opts {
-		opt(&options)
-	}
-
-	return NewCommandWithOptions(options)
+	return NewCommandWithOptions(buildOptions(opts))
 }
 
 // NewCommandWithOptions creates a new root command with colored help output
@@ -185,26 +212,25 @@ func NewCommandWithOptions(opts Options) *cli.Command {
 // using default colors. Call this after adding subcommands to ensure they
 // get colored help output.
 func Apply(cmd *cli.Command) {
-	ApplyWithOptions(cmd, defaultOptions())
+	_, cmdTpl := defaultTemplates()
+
+	writer := cmd.Writer
+	if writer == nil {
+		writer = color.Output
+	}
+
+	errWriter := cmd.ErrWriter
+	if errWriter == nil {
+		errWriter = color.Error
+	}
+
+	applyTemplates(cmd.Commands, cmdTpl, writer, errWriter)
 }
 
 // ApplyWith recursively sets colored help templates on all subcommands of cmd
 // using functional options. Call this after adding subcommands.
 func ApplyWith(cmd *cli.Command, opts ...Option) {
-	options := Options{
-		Blue:    nil,
-		Cyan:    nil,
-		Green:   nil,
-		Red:     nil,
-		Yellow:  nil,
-		Disable: false,
-	}
-
-	for _, opt := range opts {
-		opt(&options)
-	}
-
-	ApplyWithOptions(cmd, options)
+	ApplyWithOptions(cmd, buildOptions(opts))
 }
 
 // ApplyWithOptions recursively sets colored help templates on all subcommands
@@ -212,99 +238,123 @@ func ApplyWith(cmd *cli.Command, opts ...Option) {
 func ApplyWithOptions(cmd *cli.Command, opts Options) {
 	opts = resolveOptions(opts)
 	tpl := commandHelpTemplate(opts)
-	applyTemplates(cmd.Commands, tpl)
+
+	var (
+		writer    = color.Output
+		errWriter = color.Error
+	)
+
+	if opts.Disable {
+		writer = os.Stdout
+		errWriter = os.Stderr
+	}
+
+	applyTemplates(cmd.Commands, tpl, writer, errWriter)
 }
 
-func applyTemplates(cmds []*cli.Command, tpl string) {
+func applyTemplates(cmds []*cli.Command, tpl string, writer, errWriter io.Writer) {
 	for _, sub := range cmds {
 		if sub.CustomHelpTemplate == "" {
 			sub.CustomHelpTemplate = tpl
 		}
 
-		applyTemplates(sub.Commands, tpl)
+		if sub.Writer == nil {
+			sub.Writer = writer
+		}
+
+		if sub.ErrWriter == nil {
+			sub.ErrWriter = errWriter
+		}
+
+		applyTemplates(sub.Commands, tpl, writer, errWriter)
 	}
 }
 
 func rootCommandHelpTemplate(opts Options) string {
-	return fmt.Sprintf(
-		`%s
-   {{$v := offset .FullName 6}}%s{{if .Usage}} - {{wrap .Usage $v}}{{end}}
+	var buf strings.Builder
 
-%s
-   {{if .UsageText}}{{wrap .UsageText 3}}{{else}}%s `+
-			`{{if .VisibleFlags}}[global options]{{end}}`+
-			`{{if .VisibleCommands}} [command [command options]]{{end}} `+
-			`{{if .ArgsUsage}}{{.ArgsUsage}}{{else}}`+
-			`{{if .Arguments}}[arguments...]{{end}}{{end}}{{end}}`+
-			`{{if .Version}}{{if not .HideVersion}}
+	buf.WriteString(opts.Yellow("NAME:"))
+	buf.WriteString("\n   {{$v := offset .FullName 6}}")
+	buf.WriteString(opts.Green("{{wrap .FullName 3}}"))
+	buf.WriteString("{{if .Usage}} - {{wrap .Usage $v}}{{end}}\n\n")
 
-%s
-   {{.Version}}{{end}}{{end}}{{if .Description}}
+	buf.WriteString(opts.Yellow("USAGE:"))
+	buf.WriteString("\n   {{if .UsageText}}{{wrap .UsageText 3}}{{else}}")
+	buf.WriteString(opts.Cyan("{{.FullName}}"))
+	buf.WriteString(" {{if .VisibleFlags}}[global options]{{end}}")
+	buf.WriteString("{{if .VisibleCommands}} [command [command options]]{{end}} ")
+	buf.WriteString("{{if .ArgsUsage}}{{.ArgsUsage}}{{else}}")
+	buf.WriteString("{{if .Arguments}}[arguments...]{{end}}{{end}}{{end}}")
 
-%s
-   {{template "descriptionTemplate" .}}{{end}}
-{{- if len .Authors}}
+	buf.WriteString("{{if .Version}}{{if not .HideVersion}}\n\n")
+	buf.WriteString(opts.Yellow("VERSION:"))
+	buf.WriteString("\n   {{.Version}}{{end}}{{end}}")
 
-%s{{with $length := len .Authors}}`+
-			`{{if ne 1 $length}}%s{{end}}{{end}}%s
-   {{range $index, $author := .Authors}}{{if $index}}
-   {{end}}%s{{end}}{{end}}{{if .VisibleCommands}}
+	buf.WriteString("{{if .Description}}\n\n")
+	buf.WriteString(opts.Yellow("DESCRIPTION:"))
+	buf.WriteString("\n   {{template \"descriptionTemplate\" .}}{{end}}")
 
-%s{{template "visibleCommandCategoryTemplate" .}}{{end}}`+
-			`{{if .VisibleFlagCategories}}
+	buf.WriteString("\n{{- if len .Authors}}\n\n")
+	buf.WriteString(opts.Yellow("AUTHOR"))
+	buf.WriteString("{{with $length := len .Authors}}{{if ne 1 $length}}")
+	buf.WriteString(opts.Yellow("S"))
+	buf.WriteString("{{end}}{{end}}")
+	buf.WriteString(opts.Yellow(":"))
+	buf.WriteString("\n   {{range $index, $author := .Authors}}{{if $index}}\n   {{end}}")
+	buf.WriteString(opts.Blue("{{$author}}"))
+	buf.WriteString("{{end}}{{end}}")
 
-%s{{template "visibleFlagCategoryTemplate" .}}`+
-			`{{else if .VisibleFlags}}
+	buf.WriteString("{{if .VisibleCommands}}\n\n")
+	buf.WriteString(opts.Yellow("COMMANDS:"))
+	buf.WriteString("{{template \"visibleCommandCategoryTemplate\" .}}{{end}}")
 
-%s{{template "visibleFlagTemplate" .}}{{end}}{{if .Copyright}}
+	buf.WriteString("{{if .VisibleFlagCategories}}\n\n")
+	buf.WriteString(opts.Yellow("GLOBAL OPTIONS:"))
+	buf.WriteString("{{template \"visibleFlagCategoryTemplate\" .}}")
+	buf.WriteString("{{else if .VisibleFlags}}\n\n")
+	buf.WriteString(opts.Yellow("GLOBAL OPTIONS:"))
+	buf.WriteString("{{template \"visibleFlagTemplate\" .}}{{end}}")
 
-%s
-   {{template "copyrightTemplate" .}}{{end}}
-`, opts.Yellow("NAME:"),
-		opts.Green("{{wrap .FullName 3}}"),
-		opts.Yellow("USAGE:"),
-		opts.Cyan("{{.FullName}}"),
-		opts.Yellow("VERSION:"),
-		opts.Yellow("DESCRIPTION:"),
-		opts.Yellow("AUTHOR"),
-		opts.Yellow("S"),
-		opts.Yellow(":"),
-		opts.Blue("{{$author}}"),
-		opts.Yellow("COMMANDS:"),
-		opts.Yellow("GLOBAL OPTIONS:"),
-		opts.Yellow("GLOBAL OPTIONS:"),
-		opts.Yellow("COPYRIGHT:"),
-	)
+	buf.WriteString("{{if .Copyright}}\n\n")
+	buf.WriteString(opts.Red("COPYRIGHT:"))
+	buf.WriteString("\n   {{template \"copyrightTemplate\" .}}{{end}}\n")
+
+	return buf.String()
 }
 
 func commandHelpTemplate(opts Options) string {
-	return fmt.Sprintf(
-		`%s
-   {{$v := offset .FullName 6}}%s{{if .Usage}} - {{wrap .Usage $v}}{{end}}
+	var buf strings.Builder
 
-%s
-   {{template "usageTemplate" .}}{{if .Category}}
+	buf.WriteString(opts.Yellow("NAME:"))
+	buf.WriteString("\n   {{$v := offset .FullName 6}}")
+	buf.WriteString(opts.Green("{{wrap .FullName 3}}"))
+	buf.WriteString("{{if .Usage}} - {{wrap .Usage $v}}{{end}}\n\n")
 
-%s
-   {{.Category}}{{end}}{{if .Description}}
+	buf.WriteString(opts.Yellow("USAGE:"))
+	buf.WriteString("\n   {{template \"usageTemplate\" .}}")
 
-%s
-   {{template "descriptionTemplate" .}}{{end}}{{if .VisibleFlagCategories}}
+	buf.WriteString("{{if .Category}}\n\n")
+	buf.WriteString(opts.Yellow("CATEGORY:"))
+	buf.WriteString("\n   {{.Category}}{{end}}")
 
-%s{{template "visibleFlagCategoryTemplate" .}}`+
-			`{{else if .VisibleFlags}}
+	buf.WriteString("{{if .Description}}\n\n")
+	buf.WriteString(opts.Yellow("DESCRIPTION:"))
+	buf.WriteString("\n   {{template \"descriptionTemplate\" .}}{{end}}")
 
-%s{{template "visibleFlagTemplate" .}}{{end}}`+
-			`{{if .VisiblePersistentFlags}}
+	buf.WriteString("{{if .VisibleCommands}}\n\n")
+	buf.WriteString(opts.Yellow("COMMANDS:"))
+	buf.WriteString("{{template \"visibleCommandCategoryTemplate\" .}}{{end}}")
 
-%s{{template "visiblePersistentFlagTemplate" .}}{{end}}
-`, opts.Yellow("NAME:"),
-		opts.Green("{{wrap .FullName 3}}"),
-		opts.Yellow("USAGE:"),
-		opts.Yellow("CATEGORY:"),
-		opts.Yellow("DESCRIPTION:"),
-		opts.Yellow("OPTIONS:"),
-		opts.Yellow("OPTIONS:"),
-		opts.Yellow("GLOBAL OPTIONS:"),
-	)
+	buf.WriteString("{{if .VisibleFlagCategories}}\n\n")
+	buf.WriteString(opts.Yellow("OPTIONS:"))
+	buf.WriteString("{{template \"visibleFlagCategoryTemplate\" .}}")
+	buf.WriteString("{{else if .VisibleFlags}}\n\n")
+	buf.WriteString(opts.Yellow("OPTIONS:"))
+	buf.WriteString("{{template \"visibleFlagTemplate\" .}}{{end}}")
+
+	buf.WriteString("{{if .VisiblePersistentFlags}}\n\n")
+	buf.WriteString(opts.Yellow("GLOBAL OPTIONS:"))
+	buf.WriteString("{{template \"visiblePersistentFlagTemplate\" .}}{{end}}\n")
+
+	return buf.String()
 }

--- a/ccli_test.go
+++ b/ccli_test.go
@@ -13,7 +13,19 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
-const testAppName = "testapp"
+const (
+	testAppName    = "testapp"
+	testCustom     = "custom"
+	testHelpFlag   = "--help"
+	testGreetName  = "greet"
+	testGreetUsage = "say hello"
+	testParentName = "parent"
+	testChildName  = "child"
+	testChildUsage = "child command"
+	testSubName    = "sub"
+	testWorldName  = "world"
+	testNameHeader = "NAME:"
+)
 
 func noColorOptions() ccli.Options {
 	return ccli.Options{
@@ -58,7 +70,7 @@ func TestNewCommandWith(t *testing.T) {
 	custom := ccli.ColorFunc(func(_ ...any) string {
 		called = true
 
-		return "custom"
+		return testCustom
 	})
 
 	cmd := ccli.NewCommandWith(
@@ -71,6 +83,51 @@ func TestNewCommandWith(t *testing.T) {
 
 	if !called {
 		t.Error("custom color function should have been called for templates")
+	}
+}
+
+func TestNewCommandWithAllColorOptions(t *testing.T) {
+	t.Parallel()
+
+	var blueCalled, cyanCalled, redCalled bool
+
+	cmd := ccli.NewCommandWith(
+		ccli.WithBlue(func(_ ...any) string {
+			blueCalled = true
+
+			return "blue"
+		}),
+		ccli.WithCyan(func(_ ...any) string {
+			cyanCalled = true
+
+			return "cyan"
+		}),
+		ccli.WithGreen(func(_ ...any) string {
+			return "green"
+		}),
+		ccli.WithRed(func(_ ...any) string {
+			redCalled = true
+
+			return "red"
+		}),
+		ccli.WithYellow(func(_ ...any) string {
+			return "yellow"
+		}),
+	)
+	if cmd == nil {
+		t.Fatal("NewCommandWith returned nil")
+	}
+
+	if !blueCalled {
+		t.Error("WithBlue color function should have been called")
+	}
+
+	if !cyanCalled {
+		t.Error("WithCyan color function should have been called")
+	}
+
+	if !redCalled {
+		t.Error("WithRed color function should have been called")
 	}
 }
 
@@ -98,7 +155,7 @@ func TestNewCommandWithOptions(t *testing.T) {
 	custom := ccli.ColorFunc(func(_ ...any) string {
 		called = true
 
-		return "custom"
+		return testCustom
 	})
 
 	cmd := ccli.NewCommandWithOptions(ccli.Options{
@@ -208,20 +265,20 @@ func TestCommandHelpOutput(t *testing.T) {
 	cmd := ccli.NewCommandWithOptions(noColorOptions())
 	cmd.Name = testAppName
 	cmd.Usage = "a test application"
-	cmd.Version = "1.0.0"
+	cmd.Version = exampleVersion
 	cmd.Authors = []any{"Test Author <test@test.com>"}
 
 	var buf bytes.Buffer
 
 	cmd.Writer = &buf
 
-	err := cmd.Run(context.Background(), []string{testAppName, "--help"})
+	err := cmd.Run(context.Background(), []string{testAppName, testHelpFlag})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	output := buf.String()
-	for _, expected := range []string{testAppName, "a test application", "1.0.0", "Test Author"} {
+	for _, expected := range []string{testAppName, "a test application", exampleVersion, "Test Author"} {
 		if !strings.Contains(output, expected) {
 			t.Errorf("help output missing %q, got:\n%s", expected, output)
 		}
@@ -247,13 +304,13 @@ func TestCommandHelpRenderedColorCodes(t *testing.T) {
 	})
 	cmd.Name = "colorapp"
 	cmd.Usage = "a colored app"
-	cmd.Version = "1.0.0"
+	cmd.Version = exampleVersion
 
 	var buf bytes.Buffer
 
 	cmd.Writer = &buf
 
-	err := cmd.Run(context.Background(), []string{"colorapp", "--help"})
+	err := cmd.Run(context.Background(), []string{"colorapp", testHelpFlag})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -289,8 +346,8 @@ func TestSubcommandHelpOutput(t *testing.T) {
 	cmd.Name = testAppName
 	cmd.Commands = []*cli.Command{
 		{
-			Name:  "greet",
-			Usage: "say hello",
+			Name:  testGreetName,
+			Usage: testGreetUsage,
 			Action: func(_ context.Context, _ *cli.Command) error {
 				return nil
 			},
@@ -301,13 +358,13 @@ func TestSubcommandHelpOutput(t *testing.T) {
 
 	cmd.Writer = &buf
 
-	err := cmd.Run(context.Background(), []string{testAppName, "greet", "--help"})
+	err := cmd.Run(context.Background(), []string{testAppName, testGreetName, testHelpFlag})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	output := buf.String()
-	for _, expected := range []string{"greet", "say hello", "NAME:", "USAGE:"} {
+	for _, expected := range []string{testGreetName, testGreetUsage, testNameHeader, "USAGE:"} {
 		if !strings.Contains(output, expected) {
 			t.Errorf("subcommand help output missing %q, got:\n%s", expected, output)
 		}
@@ -321,12 +378,12 @@ func TestNestedSubcommandHelpOutput(t *testing.T) {
 	cmd.Name = testAppName
 	cmd.Commands = []*cli.Command{
 		{
-			Name:  "parent",
+			Name:  testParentName,
 			Usage: "parent command",
 			Commands: []*cli.Command{
 				{
-					Name:  "child",
-					Usage: "child command",
+					Name:  testChildName,
+					Usage: testChildUsage,
 					Action: func(_ context.Context, _ *cli.Command) error {
 						return nil
 					},
@@ -339,13 +396,13 @@ func TestNestedSubcommandHelpOutput(t *testing.T) {
 
 	cmd.Writer = &buf
 
-	err := cmd.Run(context.Background(), []string{testAppName, "parent", "--help"})
+	err := cmd.Run(context.Background(), []string{testAppName, testParentName, testHelpFlag})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	output := buf.String()
-	for _, expected := range []string{"parent", "child", "NAME:"} {
+	for _, expected := range []string{testParentName, testChildName, testNameHeader} {
 		if !strings.Contains(output, expected) {
 			t.Errorf("nested subcommand help output missing %q, got:\n%s", expected, output)
 		}
@@ -391,13 +448,13 @@ func TestApply(t *testing.T) {
 func TestApplyPreservesExisting(t *testing.T) {
 	t.Parallel()
 
-	custom := "custom template"
+	customTpl := "custom template"
 
 	cmd := ccli.NewCommand()
 	cmd.Commands = []*cli.Command{
 		{
-			Name:               "custom",
-			CustomHelpTemplate: custom,
+			Name:               testCustom,
+			CustomHelpTemplate: customTpl,
 		},
 		{
 			Name: "default",
@@ -406,12 +463,116 @@ func TestApplyPreservesExisting(t *testing.T) {
 
 	ccli.Apply(cmd)
 
-	if cmd.Commands[0].CustomHelpTemplate != custom {
+	if cmd.Commands[0].CustomHelpTemplate != customTpl {
 		t.Error("Apply should not overwrite existing CustomHelpTemplate")
 	}
 
 	if cmd.Commands[1].CustomHelpTemplate == "" {
 		t.Error("Apply should set CustomHelpTemplate on subcommands without one")
+	}
+}
+
+func TestApplyPropagatesWriter(t *testing.T) {
+	t.Parallel()
+
+	cmd := ccli.NewCommand()
+	cmd.Commands = []*cli.Command{
+		{
+			Name: testSubName,
+			Commands: []*cli.Command{
+				{Name: "nested"},
+			},
+		},
+	}
+
+	ccli.Apply(cmd)
+
+	if cmd.Commands[0].Writer != color.Output {
+		t.Error("Apply should propagate Writer to subcommands")
+	}
+
+	if cmd.Commands[0].ErrWriter != color.Error {
+		t.Error("Apply should propagate ErrWriter to subcommands")
+	}
+
+	nested := cmd.Commands[0].Commands[0]
+	if nested.Writer != color.Output {
+		t.Error("Apply should propagate Writer to nested subcommands")
+	}
+
+	if nested.ErrWriter != color.Error {
+		t.Error("Apply should propagate ErrWriter to nested subcommands")
+	}
+}
+
+func TestApplyFallsBackToColorWriters(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cli.Command{
+		Commands: []*cli.Command{
+			{Name: testSubName},
+		},
+	}
+
+	ccli.Apply(cmd)
+
+	if cmd.Commands[0].Writer != color.Output {
+		t.Error("Apply should fall back to color.Output when root Writer is nil")
+	}
+
+	if cmd.Commands[0].ErrWriter != color.Error {
+		t.Error("Apply should fall back to color.Error when root ErrWriter is nil")
+	}
+}
+
+func TestApplyPropagatesDisabledWriter(t *testing.T) {
+	t.Parallel()
+
+	cmd := ccli.NewCommandWith(ccli.WithDisable())
+	cmd.Commands = []*cli.Command{
+		{Name: testSubName},
+	}
+
+	ccli.Apply(cmd)
+
+	if cmd.Commands[0].Writer != os.Stdout {
+		t.Error("Apply should propagate disabled root's os.Stdout to subcommands")
+	}
+
+	if cmd.Commands[0].ErrWriter != os.Stderr {
+		t.Error("Apply should propagate disabled root's os.Stderr to subcommands")
+	}
+}
+
+func TestApplyPreservesExistingWriter(t *testing.T) {
+	t.Parallel()
+
+	var custom bytes.Buffer
+
+	cmd := ccli.NewCommand()
+	cmd.Commands = []*cli.Command{
+		{
+			Name:      testCustom,
+			Writer:    &custom,
+			ErrWriter: &custom,
+		},
+		{
+			Name: "default",
+		},
+	}
+
+	ccli.Apply(cmd)
+
+	if cmd.Commands[0].Writer != &custom {
+		t.Error("Apply should not overwrite existing Writer")
+	}
+
+	if cmd.Commands[0].ErrWriter != &custom {
+		t.Error("Apply should not overwrite existing ErrWriter")
+	}
+
+	if cmd.Commands[1].Writer != color.Output {
+		t.Error("Apply should set Writer on subcommands without one")
 	}
 }
 
@@ -427,7 +588,7 @@ func TestApplyWithOptions(t *testing.T) {
 		Disable: true,
 	})
 	cmd.Commands = []*cli.Command{
-		{Name: "sub"},
+		{Name: testSubName},
 	}
 
 	ccli.ApplyWithOptions(cmd, ccli.Options{
@@ -447,6 +608,14 @@ func TestApplyWithOptions(t *testing.T) {
 	if strings.Contains(tpl, "\033[") {
 		t.Error("disabled template should not contain ANSI escape codes")
 	}
+
+	if cmd.Commands[0].Writer != os.Stdout {
+		t.Error("disabled Apply should propagate os.Stdout to subcommands")
+	}
+
+	if cmd.Commands[0].ErrWriter != os.Stderr {
+		t.Error("disabled Apply should propagate os.Stderr to subcommands")
+	}
 }
 
 func TestApplyWith(t *testing.T) {
@@ -454,7 +623,7 @@ func TestApplyWith(t *testing.T) {
 
 	cmd := ccli.NewCommand()
 	cmd.Commands = []*cli.Command{
-		{Name: "sub"},
+		{Name: testSubName},
 	}
 
 	ccli.ApplyWith(cmd, ccli.WithDisable())
@@ -476,11 +645,11 @@ func TestSubcommandHelpOutputWithApply(t *testing.T) {
 	cmd.Name = testAppName
 	cmd.Commands = []*cli.Command{
 		{
-			Name:  "greet",
-			Usage: "say hello",
+			Name:  testGreetName,
+			Usage: testGreetUsage,
 			Commands: []*cli.Command{
 				{
-					Name:  "world",
+					Name:  testWorldName,
 					Usage: "greet the world",
 				},
 			},
@@ -493,16 +662,92 @@ func TestSubcommandHelpOutputWithApply(t *testing.T) {
 
 	cmd.Writer = &buf
 
-	err := cmd.Run(context.Background(), []string{testAppName, "greet", "world", "--help"})
+	err := cmd.Run(
+		context.Background(),
+		[]string{testAppName, testGreetName, testWorldName, testHelpFlag},
+	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	output := buf.String()
-	for _, expected := range []string{"world", "greet the world", "NAME:", "USAGE:"} {
+	for _, expected := range []string{testWorldName, "greet the world", testNameHeader, "USAGE:"} {
 		if !strings.Contains(output, expected) {
 			t.Errorf("nested subcommand help missing %q, got:\n%s", expected, output)
 		}
+	}
+}
+
+func TestCommandHelpWithSubcommands(t *testing.T) {
+	t.Parallel()
+
+	cmd := ccli.NewCommandWithOptions(noColorOptions())
+	cmd.Name = testAppName
+	cmd.Commands = []*cli.Command{
+		{
+			Name:  testParentName,
+			Usage: "parent command",
+			Commands: []*cli.Command{
+				{
+					Name:  testChildName,
+					Usage: testChildUsage,
+				},
+			},
+		},
+	}
+
+	ccli.ApplyWithOptions(cmd, noColorOptions())
+
+	var buf bytes.Buffer
+
+	cmd.Writer = &buf
+
+	err := cmd.Run(context.Background(), []string{testAppName, testParentName, testHelpFlag})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	for _, expected := range []string{"COMMANDS:", testChildName, testChildUsage} {
+		if !strings.Contains(output, expected) {
+			t.Errorf("help output missing %q, got:\n%s", expected, output)
+		}
+	}
+}
+
+func TestCopyrightUsesRedColor(t *testing.T) {
+	t.Parallel()
+
+	red := color.New(color.FgRed)
+	red.EnableColor()
+
+	cmd := ccli.NewCommandWithOptions(ccli.Options{
+		Blue:    ccli.ColorFunc(fmt.Sprint),
+		Cyan:    ccli.ColorFunc(fmt.Sprint),
+		Green:   ccli.ColorFunc(fmt.Sprint),
+		Red:     red.SprintFunc(),
+		Yellow:  ccli.ColorFunc(fmt.Sprint),
+		Disable: false,
+	})
+	cmd.Name = testAppName
+	cmd.Copyright = "2026 Test Corp"
+
+	var buf bytes.Buffer
+
+	cmd.Writer = &buf
+
+	err := cmd.Run(context.Background(), []string{testAppName, testHelpFlag})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "2026 Test Corp") {
+		t.Errorf("help output missing copyright text, got:\n%s", output)
+	}
+
+	if !strings.Contains(output, "\033[31m") {
+		t.Errorf("COPYRIGHT header should use red ANSI color, got:\n%s", output)
 	}
 }
 

--- a/example_test.go
+++ b/example_test.go
@@ -1,6 +1,9 @@
 package ccli_test
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/fatih/color"
 	"github.com/saschagrunert/ccli/v3"
 	"github.com/urfave/cli/v3"
@@ -66,4 +69,20 @@ func ExampleNewCommandWith_disable() {
 	cmd.Usage = exampleUsage
 
 	// cmd.Run(context.Background(), os.Args)
+}
+
+func ExampleNewCommandWith_run() {
+	cmd := ccli.NewCommandWith(ccli.WithDisable())
+	cmd.Name = "demo"
+	cmd.Action = func(_ context.Context, _ *cli.Command) error {
+		fmt.Println("hello from demo")
+
+		return nil
+	}
+
+	err := cmd.Run(context.Background(), []string{"demo"})
+	if err != nil {
+		return
+	}
+	// Output: hello from demo
 }


### PR DESCRIPTION
- Cache default templates via sync.Once for zero-alloc NewCommand calls
- Add COMMANDS section to subcommand help template
- Use Red color for COPYRIGHT section as documented in Options
- Propagate Writer/ErrWriter to subcommands in Apply
- Refactor templates from fmt.Sprintf to strings.Builder
- Extract buildOptions helper to deduplicate option construction
- Add tests for WithBlue, WithCyan, WithRed, writer propagation,
  and subcommand COMMANDS rendering (100% library coverage)
- Add testable example that exercises cmd.Run
- Add race detection, coverage reporting, and benchmark CI job
- Add github-actions ecosystem to Dependabot
- Update golangci-lint to v2.13.1
- Replace deprecated exhaustruct/gomodguard with v5/v2 variants
- Add clickhouselint linter and golines formatter